### PR TITLE
Raise an exception when a remote file is unavailable

### DIFF
--- a/pythesint/cf_vocabulary.py
+++ b/pythesint/cf_vocabulary.py
@@ -9,7 +9,11 @@ class CFVocabulary(JSONVocabulary):
     def _fetch_online_data(self):
         # Note the version number... Would probably be better to make it always
         # take the last version..
-        r = requests.get(self.url)
+        try:
+            r = requests.get(self.url)
+        except requests.RequestException:
+            print("Could not get the vocabulary file at '{}'".format(self.url))
+            raise
         dom = parseString(r.text.encode('utf-8').strip())
         # should only contain the standard_name_table:
         node = dom.childNodes[0]

--- a/pythesint/gcmd_vocabulary.py
+++ b/pythesint/gcmd_vocabulary.py
@@ -11,7 +11,12 @@ class GCMDVocabulary(JSONVocabulary):
         ''' Return list of GCMD standard keywords
             self.url and self.categories must be set
         '''
-        r = requests.get(self.url, verify=False)
+        try:
+            r = requests.get(self.url, verify=False)
+            r.raise_for_status()
+        except requests.RequestException:
+            print("Could not get the vocabulary file at '{}'".format(self.url))
+            raise
         rlines = [line for line in r.text.splitlines()]
         gcmd_list = []
         _read_revision(rlines[0], gcmd_list)

--- a/pythesint/tests/test_cf_vocabulary.py
+++ b/pythesint/tests/test_cf_vocabulary.py
@@ -1,0 +1,12 @@
+import unittest
+
+import requests
+
+from pythesint.cf_vocabulary import CFVocabulary
+
+
+class CFVocabularyTest(unittest.TestCase):
+    def test_exception_on_unavailable_remote_file(self):
+        voc = CFVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
+        with self.assertRaises(requests.RequestException):
+            voc._fetch_online_data()

--- a/pythesint/tests/test_gcmd_vocabulary.py
+++ b/pythesint/tests/test_gcmd_vocabulary.py
@@ -6,7 +6,11 @@ Created on Feb 26, 2016
 from __future__ import absolute_import
 
 import unittest
+
+import requests
+
 import pythesint as pti
+from pythesint.gcmd_vocabulary import GCMDVocabulary
 
 
 class GCMDVocabularyTest(unittest.TestCase):
@@ -97,6 +101,11 @@ class GCMDVocabularyTest(unittest.TestCase):
         type = 'africa'
         a = pti.get_gcmd_location(type)
         self.assertEqual(a['Location_Type'], 'AFRICA')
+
+    def test_exception_on_unavailable_remote_file(self):
+        voc = GCMDVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
+        with self.assertRaises(requests.RequestException):
+            voc._fetch_online_data()
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']

--- a/pythesint/tests/test_wkv_vocabulary.py
+++ b/pythesint/tests/test_wkv_vocabulary.py
@@ -1,0 +1,12 @@
+import unittest
+
+import requests
+
+from pythesint.wkv_vocabulary import WKVVocabulary
+
+
+class WKVVocabularyTest(unittest.TestCase):
+    def test_exception_on_unavailable_remote_file(self):
+        voc = WKVVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
+        with self.assertRaises(requests.RequestException):
+            voc._fetch_online_data()

--- a/pythesint/wkv_vocabulary.py
+++ b/pythesint/wkv_vocabulary.py
@@ -9,6 +9,10 @@ from pythesint.json_vocabulary import JSONVocabulary
 class WKVVocabulary(JSONVocabulary):
     def _fetch_online_data(self):
         ''' Return list of Well Known Variables from Nansat        '''
-        r = requests.get(self.url)
+        try:
+            r = requests.get(self.url)
+        except requests.RequestException:
+            print("Could not get the vocabulary file at '{}'".format(self.url))
+            raise
         return yaml.load(r.text)
 


### PR DESCRIPTION
Resolves #32 
Raise an exception when a request fails, so that the cause of such errors is clearer.