### PR TITLE
Remove empty dict from sort_list() output

### DIFF
--- a/pythesint/tests/test_vocabulary.py
+++ b/pythesint/tests/test_vocabulary.py
@@ -58,6 +58,12 @@ class VocabularyTest(unittest.TestCase):
         vocab.get_list = MagicMock(return_value=self.test_list)
         self.assertEqual(vocab.search('Cat'), [self.cat, self.cat2])
 
+    def test_no_empty_dict_in_sort_output(self):
+        vocabulary = Vocabulary('test_vocabulary', categories=['foo', 'bar'])
+        entry = {'foo': 'a', 'bar': 'b'}
+        vocabulary_list = [{'Revision': '2016-01-08 13:40:40'}, entry]
+        self.assertListEqual(vocabulary.sort_list(vocabulary_list), [OrderedDict(entry)])
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']

--- a/pythesint/vocabulary.py
+++ b/pythesint/vocabulary.py
@@ -84,11 +84,11 @@ class Vocabulary(object):
         retlist = []
         for dd in list:
             line_kw = OrderedDict()
-            for _, key in enumerate(self.categories):
-                try:
+            try:
+                for key in self.categories:
                     line_kw[key] = dd[key]
-                except KeyError:
-                    continue
+            except KeyError:
+                continue
             retlist.append(line_kw)
         return retlist
 


### PR DESCRIPTION
Resolves #43 

One behavior is slightly altered: entries having correct field names, but not all fields present won't be included in the output anymore.

FYI @mortenwh 