### PR TITLE
Pin vocabulary versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 pythesint.egg-info
 dist
 record.txt
+.coverage

--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ pti.get_gcmd_platform('ENVISAT')
 pti.get_gcmd_provider('NERSC')
 ```
 
+For JSON vocabularies, it is possible to update the local files using a specific version.
+The format of the version depends on the provider.
+If no version is provided, the latest version is retrieved.
+
+```python
+import pythesint as pti
+pti.update_gcmd_instrument(version='9.1.5')
+pti.update_cf_standard_name(version='20210119T185509')
+pti.update_mmd_platform_type(version='a5c8573')
+```
+
+or
+
+```python
+import pythesint as pti
+pti.update_all_vocabularies(versions={
+    'gcmd_instrument': '9.1.5',
+    'cf_standard_name': '20210119T185509',
+    'mmd_platform_type': 'a5c8573'
+})
+```
+
 ## Standards
 
 The package follows the standards defined at NASA's Global Change Master Directory (GCMD) (http://gcmd.gsfc.nasa.gov) and the NetCDF-CF conventions (http://cfconventions.org/), plus possibly others that will be added as needs emerge... The standards are mapped in Python dictionaries and saved to json-files.

--- a/pythesint/cf_vocabulary.py
+++ b/pythesint/cf_vocabulary.py
@@ -7,7 +7,7 @@ from pythesint.json_vocabulary import JSONVocabulary
 
 
 class CFVocabulary(JSONVocabulary):
-    def _fetch_online_data(self):
+    def _fetch_online_data(self, version=None):
         try:
             r = requests.get(self.url)
         except requests.RequestException:

--- a/pythesint/cf_vocabulary.py
+++ b/pythesint/cf_vocabulary.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import xml
 from xml.dom.minidom import parseString
 import requests
 from pythesint.json_vocabulary import JSONVocabulary

--- a/pythesint/cf_vocabulary.py
+++ b/pythesint/cf_vocabulary.py
@@ -8,8 +8,13 @@ from pythesint.json_vocabulary import JSONVocabulary
 
 class CFVocabulary(JSONVocabulary):
     def _fetch_online_data(self, version=None):
+        if version:
+            params = {'version': version}
+        else:
+            params = {}
+
         try:
-            r = requests.get(self.url)
+            r = requests.get(self.url, params=params)
         except requests.RequestException:
             print("Could not get the vocabulary file at '{}'".format(self.url))
             raise

--- a/pythesint/gcmd_vocabulary.py
+++ b/pythesint/gcmd_vocabulary.py
@@ -7,7 +7,7 @@ from pythesint.json_vocabulary import JSONVocabulary
 
 
 class GCMDVocabulary(JSONVocabulary):
-    def _fetch_online_data(self):
+    def _fetch_online_data(self, version=None):
         ''' Return list of GCMD standard keywords
             self.url and self.categories must be set
         '''

--- a/pythesint/gcmd_vocabulary.py
+++ b/pythesint/gcmd_vocabulary.py
@@ -11,8 +11,13 @@ class GCMDVocabulary(JSONVocabulary):
         ''' Return list of GCMD standard keywords
             self.url and self.categories must be set
         '''
+        if version:
+            params = {'version': version}
+        else:
+            params = {}
+
         try:
-            r = requests.get(self.url, verify=False)
+            r = requests.get(self.url, verify=False, params=params)
             r.raise_for_status()
         except requests.RequestException:
             print("Could not get the vocabulary file at '{}'".format(self.url))
@@ -34,7 +39,10 @@ def _read_revision(line, gcmd_list):
     # TODO: Cast exception if not found?
     if 'Keyword Version' and 'Revision' in line:
         meta = line.split('","')
-        gcmd_list.append({'Revision': meta[1][10:]})
+        gcmd_list.append({
+            'Revision': meta[1][10:],
+            'Keyword Version': meta[0].split(': ')[1]
+        })
 
 
 def _check_categories(line, categories):

--- a/pythesint/json_vocabulary.py
+++ b/pythesint/json_vocabulary.py
@@ -18,7 +18,7 @@ class JSONVocabulary(Vocabulary):
             result = json.load(opened_file)
         return self.sort_list(result)
 
-    def update(self):
+    def update(self, version=None):
         ''' Write vocabulary to a JSON file '''
         print('Downloading and writing json file for %s' % self.name)
         json_path = os.path.split(self.get_filepath())[0]
@@ -26,7 +26,7 @@ class JSONVocabulary(Vocabulary):
         if not os.path.exists(json_path):
             os.makedirs(json_path)
         with open(self.get_filepath(), 'w') as out:
-            json.dump(self._fetch_online_data(), out, indent=4)
+            json.dump(self._fetch_online_data(version=version), out, indent=4)
 
     def get_filepath(self):
         return os.path.join(DATA_HOME, self.get_relative_path())

--- a/pythesint/json_vocabulary.py
+++ b/pythesint/json_vocabulary.py
@@ -7,6 +7,10 @@ from pythesint.vocabulary import Vocabulary
 from pythesint.pathsolver import DATA_HOME
 
 class JSONVocabulary(Vocabulary):
+
+    def _fetch_online_data(self, version=None):
+        raise NotImplementedError
+
     def get_relative_path(self):
         return os.path.join('pythesint', 'json', '%s_list.json' % self.name.lower())
 

--- a/pythesint/json_vocabulary.py
+++ b/pythesint/json_vocabulary.py
@@ -24,6 +24,11 @@ class JSONVocabulary(Vocabulary):
 
     def update(self, version=None):
         ''' Write vocabulary to a JSON file '''
+        if not version:
+            try:
+                version = self.version
+            except AttributeError:
+                version = None
         print('Downloading and writing json file for %s' % self.name)
         json_path = os.path.split(self.get_filepath())[0]
         print(json_path)

--- a/pythesint/mmd_vocabulary.py
+++ b/pythesint/mmd_vocabulary.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
 import xml.dom.minidom
+import re
 import requests
 from collections import OrderedDict
 
+import pythesint.utils as utils
 from pythesint.json_vocabulary import JSONVocabulary
 
 class MMDBaseVocabulary(JSONVocabulary):
@@ -18,8 +20,13 @@ class MMDBaseVocabulary(JSONVocabulary):
             return ''
 
     def _fetch_online_data(self, version=None):
+        if version:
+            url = utils.set_github_version(self.url, version)
+        else:
+            url = self.url
+
         try:
-            r = requests.get(self.url)
+            r = requests.get(url)
         except requests.RequestException:
             print("Could not get the vocabulary file at '{}'".format(self.url))
             raise
@@ -33,6 +40,9 @@ class MMDBaseVocabulary(JSONVocabulary):
                 'aboutCollection': node.getAttribute('rdf:about'),
                 'prefLabelCollection': label,
                 'definitionCollection': definition})
+
+        if version:
+            details['version'] = version
 
         mmd_list = [details]
         for cnode in node.getElementsByTagName('skos:member'):

--- a/pythesint/mmd_vocabulary.py
+++ b/pythesint/mmd_vocabulary.py
@@ -17,7 +17,7 @@ class MMDBaseVocabulary(JSONVocabulary):
         except IndexError:
             return ''
 
-    def _fetch_online_data(self):
+    def _fetch_online_data(self, version=None):
         try:
             r = requests.get(self.url)
         except requests.RequestException:

--- a/pythesint/mmd_vocabulary.py
+++ b/pythesint/mmd_vocabulary.py
@@ -36,10 +36,10 @@ class MMDBaseVocabulary(JSONVocabulary):
 
         label = self.get_subnode_data(node, 'skos:prefLabel')
         definition = self.get_subnode_data(node, 'skos:definition')
-        details = OrderedDict({
-                'aboutCollection': node.getAttribute('rdf:about'),
-                'prefLabelCollection': label,
-                'definitionCollection': definition})
+        details = OrderedDict([
+            ('aboutCollection', node.getAttribute('rdf:about')),
+            ('prefLabelCollection', label),
+            ('definitionCollection', definition)])
 
         if version:
             details['version'] = version
@@ -56,10 +56,10 @@ class MMDBaseVocabulary(JSONVocabulary):
                 label = self.get_subnode_data(concept, 'skos:prefLabel')
                 definition = self.get_subnode_data(concept, 'skos:definition')
 
-                access_constraint = OrderedDict({
-                    'prefLabel': label,
-                    'definition': definition
-                })
+                access_constraint = OrderedDict([
+                    ('prefLabel', label),
+                    ('definition', definition)
+                ])
                 mmd_list.append(access_constraint)
         return mmd_list
 

--- a/pythesint/pythesint.py
+++ b/pythesint/pythesint.py
@@ -4,10 +4,18 @@ from pkg_resources import resource_string
 
 import yaml
 
-def update_all_vocabularies():
+def update_all_vocabularies(versions=None):
     ''' Update all vocabularies '''
+    if not versions:
+            versions = {}
     for name in vocabularies.keys():
-        vocabularies[name].update()
+        version = versions.get(name)
+        if not version:
+            try:
+                version = vocabularies[name].version
+            except AttributeError:
+                version = None
+        vocabularies[name].update(version=version)
 
 def _process_config():
     ''' Load info about all vocabularies from config and add to module '''

--- a/pythesint/tests/test_cf_vocabulary.py
+++ b/pythesint/tests/test_cf_vocabulary.py
@@ -1,4 +1,6 @@
 import unittest
+
+import mock.mock as mock
 import requests
 
 from pythesint.cf_vocabulary import CFVocabulary
@@ -8,3 +10,27 @@ class CFVocabularyTest(unittest.TestCase):
         voc = CFVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
         with self.assertRaises(requests.RequestException):
             voc._fetch_online_data()
+
+    def test_fetch_version(self):
+        """Test that the specified version is fetched"""
+        voc = CFVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
+        # We use the exception as side effect to skip the part of the
+        # method we are not testing.
+        # TODO: split _fetch_online_data() into several methods instead
+        with mock.patch('requests.get', side_effect=requests.RequestException) as mock_get:
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data()
+            mock_get.assert_called_with('https://sdfghdfghd.nersc.no', params={})
+
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data(version=None)
+            mock_get.assert_called_with('https://sdfghdfghd.nersc.no', params={})
+
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data(version='')
+            mock_get.assert_called_with('https://sdfghdfghd.nersc.no', params={})
+
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data(version='9.1.5')
+            mock_get.assert_called_with(
+                'https://sdfghdfghd.nersc.no', params={'version': '9.1.5'})

--- a/pythesint/tests/test_gcmd_vocabulary.py
+++ b/pythesint/tests/test_gcmd_vocabulary.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 
 import unittest
 
+import mock.mock as mock
 import requests
 
 import pythesint as pti
@@ -108,6 +109,30 @@ class GCMDVocabularyTest(unittest.TestCase):
         voc = GCMDVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
         with self.assertRaises(requests.RequestException):
             voc._fetch_online_data()
+
+    def test_fetch_version(self):
+        """Test that the specified version is fetched"""
+        voc = GCMDVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
+        # We use the exception as side effect to skip the part of the
+        # method we are not testing.
+        # TODO: split _fetch_online_data() into several methods instead
+        with mock.patch('requests.get', side_effect=requests.RequestException) as mock_get:
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data()
+            mock_get.assert_called_with('https://sdfghdfghd.nersc.no', verify=False, params={})
+
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data(version=None)
+            mock_get.assert_called_with('https://sdfghdfghd.nersc.no', verify=False, params={})
+
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data(version='')
+            mock_get.assert_called_with('https://sdfghdfghd.nersc.no', verify=False, params={})
+
+            with self.assertRaises(requests.RequestException):
+                voc._fetch_online_data(version='9.1.5')
+            mock_get.assert_called_with(
+                'https://sdfghdfghd.nersc.no', verify=False, params={'version': '9.1.5'})
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']

--- a/pythesint/tests/test_gcmd_vocabulary.py
+++ b/pythesint/tests/test_gcmd_vocabulary.py
@@ -25,7 +25,9 @@ class GCMDVocabularyTest(unittest.TestCase):
                 '/instruments/?format=xml"')
         pti.gcmd_vocabulary._read_revision(line, gcmd_list)
         self.assertEqual(len(gcmd_list), 1)
-        self.assertDictEqual(gcmd_list[0], {'Revision': '2016-01-08 13:40:40'})
+        self.assertDictEqual(
+            gcmd_list[0],
+            {'Keyword Version': '8.1', 'Revision': '2016-01-08 13:40:40'})
 
     def test_check_categories(self):
         line = ('Category,Class,Type,Subtype,Short_Name,Long_Name,UUID')

--- a/pythesint/tests/test_json_vocabulary.py
+++ b/pythesint/tests/test_json_vocabulary.py
@@ -1,0 +1,58 @@
+'''
+Created on Feb 25, 2016
+
+@author: alevin
+'''
+from __future__ import absolute_import
+
+import unittest
+import mock.mock as mock
+try:
+    from StringIO import StringIO  # python 2
+    StringIO.__enter__ = lambda *args: args[0]
+    StringIO.__exit__ = lambda *args: args[0]
+except ImportError:
+    from io import StringIO  # python 3
+
+
+from pythesint.json_vocabulary import JSONVocabulary
+
+
+class JSONVocabularyTest(unittest.TestCase):
+
+    def setUp(self):
+        patch_fetch = mock.patch.object(JSONVocabulary, '_fetch_online_data', return_value=[])
+        self.mock_fetch = patch_fetch.start()
+        self.addCleanup(patch_fetch.stop)
+
+    def test_update_no_version(self):
+        """no version is provided"""
+        vocabulary = JSONVocabulary(name='test')
+        # avoid writing to a real file
+        with mock.patch('pythesint.json_vocabulary.open', return_value=StringIO()):
+            vocabulary.update()
+            vocabulary._fetch_online_data.assert_called_with(version=None)
+
+    def test_update_with_version(self):
+        """a version is provided as argument"""
+        vocabulary = JSONVocabulary(name='test')
+        # avoid writing to a real file
+        with mock.patch('pythesint.json_vocabulary.open', return_value=StringIO()):
+            vocabulary.update(version='9.1.5')
+            vocabulary._fetch_online_data.assert_called_with(version='9.1.5')
+
+    def test_update_version_in_config(self):
+        """a version is provided in the configuration"""
+        vocabulary = JSONVocabulary(name='test', version='9.1.4')
+        # avoid writing to a real file
+        with mock.patch('pythesint.json_vocabulary.open', return_value=StringIO()):
+            vocabulary.update()
+            vocabulary._fetch_online_data.assert_called_with(version='9.1.4')
+
+    def test_update_override_config_version(self):
+        """"""
+        vocabulary = JSONVocabulary(name='test', version='9.1.4')
+        # avoid writing to a real file
+        with mock.patch('pythesint.json_vocabulary.open', return_value=StringIO()):
+            vocabulary.update(version='9.1.5')
+            vocabulary._fetch_online_data.assert_called_with(version='9.1.5')

--- a/pythesint/tests/test_mmd_vocabulary.py
+++ b/pythesint/tests/test_mmd_vocabulary.py
@@ -1,4 +1,7 @@
 import unittest
+from collections import OrderedDict
+
+import mock.mock as mock
 import requests
 
 from pythesint.mmd_vocabulary import MMDBaseVocabulary
@@ -9,3 +12,62 @@ class MMDVocabularyTest(unittest.TestCase):
         with self.assertRaises(requests.RequestException):
             voc._fetch_online_data()
 
+    def test_fetch_version(self):
+        """Test that the specified version is fetched"""
+        voc = MMDBaseVocabulary(
+            name='test_voc',
+            url='https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+        # We use the exception as side effect to skip the part of the
+        # method we are not testing.
+        # TODO: split _fetch_online_data() into several methods instead
+
+        remote_page = '''<?xml version="1.0"?>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:isothes="http://purl.org/iso25964/skos-thes#">
+            <skos:Collection rdf:about="https://vocab.met.no/mmd/concept">
+                <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
+                <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
+                <skos:prefLabel xml:lang="en">Concept label</skos:prefLabel>
+                <skos:definition xml:lang="en">Concept definition</skos:definition>
+                <skos:member>
+                <skos:Concept rdf:about="https://vocab.met.no/mmd/concept/instance">
+                    <skos:prefLabel xml:lang="en">Instance label</skos:prefLabel>
+                    <skos:definition xml:lang="en">Instance definition</skos:definition>
+                </skos:Concept>
+                </skos:member>
+            </skos:Collection>
+            </rdf:RDF>
+        '''
+
+        expected_list = [
+            OrderedDict([
+                ('aboutCollection', 'https://vocab.met.no/mmd/concept'),
+                ('prefLabelCollection', 'Concept label'),
+                ('definitionCollection', 'Concept definition')]),
+            OrderedDict([
+                ('prefLabel', 'Instance label'),
+                ('definition', 'Instance definition')])
+        ]
+
+        with mock.patch('requests.get') as mock_get:
+            # No version provided
+            mock_get.return_value.text = remote_page
+            self.assertListEqual(voc._fetch_online_data(), expected_list)
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+
+            self.assertListEqual(voc._fetch_online_data(version=None), expected_list)
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+
+            self.assertListEqual(voc._fetch_online_data(version=''), expected_list)
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+
+            # Version provided
+            version = 'a5c8573'
+            expected_list[0]['version'] = version
+            self.assertListEqual(voc._fetch_online_data(version=version), expected_list)
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/metno/mmd/a5c8573/thesauri/mmd_operstatus.xml')

--- a/pythesint/tests/test_pythesint.py
+++ b/pythesint/tests/test_pythesint.py
@@ -194,17 +194,25 @@ class PythesintTest(unittest.TestCase):
                 self.assertEqual(response.status_code, 200)
 
     def test_update_all_mocked(self):
-        orig_vocab = pti.pythesint.vocabularies
-        pti.pythesint.vocabularies = {'1': MagicMock(),
-                                      'anothervocab': MagicMock(),
-                                      'thirdvocab': MagicMock(),
-                                      'instruments': MagicMock(),
-                                      'something': MagicMock()}
-        pti.update_all_vocabularies()
-        # items() in general is inefficient on Python 2, but should be no problem with just a couple items.
-        for _, mock in pti.pythesint.vocabularies.items():
-            mock.update.assert_called_once_with()
-        pti.pythesint.vocabularies = orig_vocab
+        vocabularies_names = (
+            '1',
+            'anothervocab',
+            'thirdvocab',
+            'instruments',
+            'something'
+        )
+
+        vocabularies = {}
+        for name in vocabularies_names:
+            vocabulary_mock = MagicMock()
+            vocabulary_mock.version = None
+            vocabularies[name] = vocabulary_mock
+
+        with patch('pythesint.pythesint.vocabularies', vocabularies):
+            pti.update_all_vocabularies()
+            # items() in general is inefficient on Python 2, but should be no problem with just a couple items.
+            for _, mock in pti.pythesint.vocabularies.items():
+                mock.update.assert_called_once_with(version=None)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pythesint/tests/test_wkv_vocabulary.py
+++ b/pythesint/tests/test_wkv_vocabulary.py
@@ -1,5 +1,6 @@
 import unittest
 
+import mock.mock as mock
 import requests
 
 from pythesint.wkv_vocabulary import WKVVocabulary
@@ -10,3 +11,35 @@ class WKVVocabularyTest(unittest.TestCase):
         voc = WKVVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
         with self.assertRaises(requests.RequestException):
             voc._fetch_online_data()
+
+    def test_fetch_version(self):
+        """Test that the specified version is fetched"""
+        voc = WKVVocabulary(
+            name='test_voc',
+            url='https://raw.githubusercontent.com/nansencenter/nersc-vocabularies/master/nansat_wkv.yml')
+        # We use the exception as side effect to skip the part of the
+        # method we are not testing.
+        # TODO: split _fetch_online_data() into several methods instead
+        with mock.patch('requests.get') as mock_get:
+            mock_get.return_value.text = '[]'
+            self.assertListEqual(voc._fetch_online_data(), [])
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/nansencenter/nersc-vocabularies/master/'
+                'nansat_wkv.yml')
+
+            self.assertListEqual(voc._fetch_online_data(version=None), [])
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/nansencenter/nersc-vocabularies/master/'
+                'nansat_wkv.yml')
+
+            self.assertListEqual(voc._fetch_online_data(version=''), [])
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/nansencenter/nersc-vocabularies/master/'
+                'nansat_wkv.yml')
+
+            self.assertListEqual(
+                voc._fetch_online_data(version='91912bb'),
+                [{'version': '91912bb'}])
+            mock_get.assert_called_with(
+                'https://raw.githubusercontent.com/nansencenter/nersc-vocabularies/91912bb/'
+                'nansat_wkv.yml')

--- a/pythesint/utils.py
+++ b/pythesint/utils.py
@@ -8,5 +8,5 @@ def set_github_version(url, version):
     """
     return re.sub(
         r'(https://raw.githubusercontent.com/([^/]+/){2})[^/]+/',
-        rf'\1{version}/',
+        r'\1{}/'.format(version),
         url)

--- a/pythesint/utils.py
+++ b/pythesint/utils.py
@@ -1,0 +1,12 @@
+"""Utilities"""
+
+import re
+
+def set_github_version(url, version):
+    """Returns a modified `url` using `version`. Only works for raw
+    content URLs from github
+    """
+    return re.sub(
+        r'(https://raw.githubusercontent.com/([^/]+/){2})[^/]+/',
+        rf'\1{version}/',
+        url)

--- a/pythesint/utils.py
+++ b/pythesint/utils.py
@@ -8,5 +8,5 @@ def set_github_version(url, version):
     """
     return re.sub(
         r'(https://raw.githubusercontent.com/([^/]+/){2})[^/]+/',
-        r'\1{}/'.format(version),
+        r'\g<1>{}/'.format(version),
         url)

--- a/pythesint/vocabulary.py
+++ b/pythesint/vocabulary.py
@@ -77,7 +77,7 @@ class Vocabulary(object):
 
         return matches
 
-    def update(self):
+    def update(self, version=None):
         pass
 
     def sort_list(self, list):

--- a/pythesint/wkv_vocabulary.py
+++ b/pythesint/wkv_vocabulary.py
@@ -7,7 +7,7 @@ from pythesint.json_vocabulary import JSONVocabulary
 
 
 class WKVVocabulary(JSONVocabulary):
-    def _fetch_online_data(self):
+    def _fetch_online_data(self, version=None):
         ''' Return list of Well Known Variables from Nansat        '''
         try:
             r = requests.get(self.url)

--- a/pythesint/wkv_vocabulary.py
+++ b/pythesint/wkv_vocabulary.py
@@ -3,16 +3,29 @@ from __future__ import absolute_import
 import yaml
 import requests
 
+import pythesint.utils as utils
 from pythesint.json_vocabulary import JSONVocabulary
 
 
 class WKVVocabulary(JSONVocabulary):
     def _fetch_online_data(self, version=None):
-        ''' Return list of Well Known Variables from Nansat        '''
+        '''Return list of Well Known Variables from Nansat'''
+        if version:
+            url = utils.set_github_version(self.url, version)
+        else:
+            url = self.url
+
         try:
-            r = requests.get(self.url)
+            r = requests.get(url)
         except requests.RequestException:
             print("Could not get the vocabulary file at '{}'".format(self.url))
             raise
-        return yaml.load(r.text)
+
+        if version:
+            wkv_list = [{'version': version}]
+        else:
+            wkv_list = []
+        wkv_list.extend(yaml.load(r.text))
+
+        return wkv_list
 


### PR DESCRIPTION
Resolves #41 

Enables the user to update local JSON files using a specific version.
This can be done:
- using the `update()` method of the vocabulary:
  `pti.update_gcmd_instrument(version='9.1.5')`
- using the `update_all_vocabularies()` method:
  `pti.update_all_vocabularies(versions={'gcmd_instrument': '9.1.5'})`
- by adding a `version` key in `kwargs` in the configuration file

A version given as argument to an `update()` method (including `update_all_vocabularies()`) will override the version present in the configuration file, if there is one.