### PR TITLE
Replace travis badge with github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/nansencenter/py-thesaurus-interface.svg?branch=master)](https://travis-ci.org/nansencenter/py-thesaurus-interface)
+[![Run unit tests and build Python package](https://github.com/nansencenter/py-thesaurus-interface/actions/workflows/tests_build.yml/badge.svg)](https://github.com/nansencenter/py-thesaurus-interface/actions/workflows/tests_build.yml)
 [![Coverage Status](https://coveralls.io/repos/github/nansencenter/py-thesaurus-interface/badge.svg?branch=master)](https://coveralls.io/github/nansencenter/py-thesaurus-interface?branch=master)
 
 ## py-thesaurus-interface


### PR DESCRIPTION
Resolves #51 


The tests fail because of problems solved in the following PRs: #56 #57 #58.
I merged all pending PRs in a temporary branch to show that tests pass with all the fixes: 
https://github.com/nansencenter/py-thesaurus-interface/actions/runs/1425795952