### PR TITLE
Adapt mmd_vocabulary to the new source structure

### DIFF
--- a/pythesint/mmd_vocabulary.py
+++ b/pythesint/mmd_vocabulary.py
@@ -69,9 +69,7 @@ class MMDVocabulary(JSONVocabulary):
         local_sha = self._get_local_file_github_blob_sha(self.base_file)
         remote_sha = self._get_remote_file_github_blob_sha(version)
 
-        if (not os.path.isfile(self.base_file)
-                or os.path.getsize(self.base_file) == 0
-                or local_sha != remote_sha):
+        if (not os.path.isfile(self.base_file) or local_sha != remote_sha):
             with closing(requests.get(url, stream=True)) as response:
                 with open(self.base_file, 'wb') as f_h:
                     f_h.write(response.content)

--- a/pythesint/mmd_vocabulary.py
+++ b/pythesint/mmd_vocabulary.py
@@ -1,14 +1,23 @@
 from __future__ import absolute_import
 
+import hashlib
+import json
+import os
+import os.path
 import xml.dom.minidom
-import re
-import requests
 from collections import OrderedDict
+from contextlib import closing
+
+import requests
 
 import pythesint.utils as utils
 from pythesint.json_vocabulary import JSONVocabulary
+from pythesint.pathsolver import DATA_HOME
 
-class MMDBaseVocabulary(JSONVocabulary):
+class MMDVocabulary(JSONVocabulary):
+    base_url = 'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd-vocabulary.xml'
+    base_file = os.path.join(DATA_HOME, 'pythesint', 'mmd-vocabulary.xml')
+
     @staticmethod
     def get_subnode_data(node, subnode_name):
         """Get the data contained in a subnode. Return an empty string
@@ -19,33 +28,85 @@ class MMDBaseVocabulary(JSONVocabulary):
         except IndexError:
             return ''
 
-    def _fetch_online_data(self, version=None):
+    def get_collection(self, dom, label):
+        """Returns the collection which has the given label"""
+        for collection in dom.childNodes[0].getElementsByTagName('skos:Collection'):
+            if self.get_subnode_data(collection, 'skos:prefLabel') == label:
+                return collection
+        return None
+
+    @staticmethod
+    def _get_local_file_github_blob_sha(file_path):
+        """Get the local file's blob SHA hash as used by github"""
+        if os.path.isfile(file_path):
+            with open(file_path, 'rb') as f_h:
+                contents = f_h.read()
+            header_string = f"blob {len(contents)}\0"
+            blob = bytes(header_string, encoding='utf-8') + contents
+            return hashlib.sha1(blob).hexdigest()
+        return None
+
+    def _get_remote_file_github_blob_sha(self, version):
+        """Get the remote file's blob sha hash from github"""
+        endpoint = f"https://api.github.com/repos/metno/mmd/git/trees/{version}:thesauri"
+        result = json.loads(requests.get(endpoint).text)
+        for file_info in result['tree']:
+            if file_info['path'] == 'mmd-vocabulary.xml':
+                return file_info['sha']
+        return None
+
+    def _download_data_file(self, version=None):
+        """Download the file containing all the vocabularies
+        definitions if it is not already present
+        """
         if version:
-            url = utils.set_github_version(self.url, version)
+            url = utils.set_github_version(self.base_url, version)
         else:
-            url = self.url
+            url = self.base_url
 
-        try:
-            r = requests.get(url)
-        except requests.RequestException:
-            print("Could not get the vocabulary file at '{}'".format(self.url))
-            raise
-        dom = xml.dom.minidom.parseString(r.text.encode('utf-8').strip())
+        # by comparing the hashes, we can check if we need to
+        # download the file or not
+        local_sha = self._get_local_file_github_blob_sha(self.base_file)
+        remote_sha = self._get_remote_file_github_blob_sha(version)
+
+        if (not os.path.isfile(self.base_file)
+                or os.path.getsize(self.base_file) == 0
+                or local_sha != remote_sha):
+            with closing(requests.get(url, stream=True)) as response:
+                with open(self.base_file, 'wb') as f_h:
+                    f_h.write(response.content)
+
+    def _fetch_online_data(self, version=None):
+        """Download, if necessary, the file containing all the MMD
+        vocabularies definitions. Then extract the requested collection
+        and write it to a JSON file like any JSON vocabulary.
+        """
+        if not version:
+            version = 'master'
+
+        self._download_data_file(version=version)
+
+        with open(self.base_file, 'r', encoding='utf-8') as f_h:
+            dom = xml.dom.minidom.parse(f_h)
+
         # should only contain the standard_name_table:
-        node = dom.childNodes[0].getElementsByTagName('skos:Collection')[0]
+        # node = dom.childNodes[0].getElementsByTagName('skos:Collection')[0]
+        collection = self.get_collection(dom, self.collection_label)
 
-        label = self.get_subnode_data(node, 'skos:prefLabel')
-        definition = self.get_subnode_data(node, 'skos:definition')
+        if collection is None:
+            raise ValueError(f"'{self.collection_label}' is not a valid collection label")
+
+        definition = self.get_subnode_data(collection, 'skos:definition')
         details = OrderedDict([
-            ('aboutCollection', node.getAttribute('rdf:about')),
-            ('prefLabelCollection', label),
+            ('aboutCollection', collection.getAttribute('rdf:about')),
+            ('prefLabelCollection', self.collection_label),
             ('definitionCollection', definition)])
 
         if version:
             details['version'] = version
 
         mmd_list = [details]
-        for cnode in node.getElementsByTagName('skos:member'):
+        for cnode in collection.getElementsByTagName('skos:member'):
             # This does not work in python2.7 because type(detail)=instance
             #if type(cnode)==xml.dom.minidom.Element:
             try:
@@ -62,21 +123,3 @@ class MMDBaseVocabulary(JSONVocabulary):
                 ])
                 mmd_list.append(access_constraint)
         return mmd_list
-
-class MMDAccessConstraints(MMDBaseVocabulary):
-    pass
-
-class MMDActivityType(MMDBaseVocabulary):
-    pass
-
-class MMDAreas(MMDBaseVocabulary):
-    pass
-
-class MMDOperStatus(MMDBaseVocabulary):
-    pass
-
-class MMDPlatformType(MMDBaseVocabulary):
-    pass
-
-class MMDUseConstraintType(MMDBaseVocabulary):
-    pass

--- a/pythesint/pythesintrc.yaml
+++ b/pythesint/pythesintrc.yaml
@@ -136,54 +136,54 @@
 
 - name: mmd_access_constraints
   module: mmd_vocabulary
-  class: MMDAccessConstraints
+  class: MMDVocabulary
   kwargs:
-    url: https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_access_constraints.xml
+    collection_label: 'Access Constraint'
     categories:
       - prefLabel
       - definition
 
 - name: mmd_activity_type
   module: mmd_vocabulary
-  class: MMDActivityType
+  class: MMDVocabulary
   kwargs:
-    url: https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_activity_type.xml
+    collection_label: 'Activity Type'
     categories:
       - prefLabel
       - definition
 
 - name: mmd_areas
   module: mmd_vocabulary
-  class: MMDAreas
+  class: MMDVocabulary
   kwargs:
-    url: https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_areas.xml
+    collection_label: 'Geographical Areas'
     categories:
       - prefLabel
       - definition
 
 - name: mmd_operstatus
   module: mmd_vocabulary
-  class: MMDOperStatus
+  class: MMDVocabulary
   kwargs:
-    url: https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml
+    collection_label: 'Operational Status'
     categories:
       - prefLabel
       - definition
 
 - name: mmd_platform_type
   module: mmd_vocabulary
-  class: MMDPlatformType
+  class: MMDVocabulary
   kwargs:
-    url: https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_platform_type.xml
+    collection_label: 'Platform'
     categories:
       - prefLabel
       - definition
 
 - name: mmd_use_constraint_type
   module: mmd_vocabulary
-  class: MMDUseConstraintType
+  class: MMDVocabulary
   kwargs:
-    url: https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_use_constraint_type.xml
+    collection_label: 'Use Constraint'
     categories:
       - prefLabel
       - definition

--- a/pythesint/tests/test_mmd_vocabulary.py
+++ b/pythesint/tests/test_mmd_vocabulary.py
@@ -39,11 +39,11 @@ class MMDVocabularyTest(unittest.TestCase):
             self.voc.get_subnode_data(collection, 'skos:definition'),
             'Concept definition')
 
-    def test_get_collection(self):
+    def test_get_element_by_label(self):
         """Test getting the collection having a particular label"""
         dom = xml.dom.minidom.parseString(self.base_file_contents)
         self.assertEqual(
-            self.voc.get_collection(dom, 'Concept label'),
+            self.voc.get_element_by_label(dom.documentElement, 'skos:Collection', 'Concept label'),
             dom.childNodes[0].getElementsByTagName('skos:Collection')[0])
 
 

--- a/pythesint/tests/test_mmd_vocabulary.py
+++ b/pythesint/tests/test_mmd_vocabulary.py
@@ -1,44 +1,57 @@
+import io
 import unittest
+import xml.dom.minidom
 from collections import OrderedDict
 
 import mock.mock as mock
-import requests
 
-from pythesint.mmd_vocabulary import MMDBaseVocabulary
+from pythesint.mmd_vocabulary import MMDVocabulary
 
 class MMDVocabularyTest(unittest.TestCase):
-    def test_exception_on_unavailable_remote_file(self):
-        voc = MMDBaseVocabulary(name='test_voc', url='https://sdfghdfghd.nersc.no')
-        with self.assertRaises(requests.RequestException):
-            voc._fetch_online_data()
 
-    def test_fetch_version(self):
-        """Test that the specified version is fetched"""
-        voc = MMDBaseVocabulary(
-            name='test_voc',
-            url='https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+    base_file_contents = '''<?xml version="1.0"?>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+            xmlns:isothes="http://purl.org/iso25964/skos-thes#">
+        <skos:Collection rdf:about="https://vocab.met.no/mmd/concept">
+            <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
+            <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
+            <skos:prefLabel xml:lang="en">Concept label</skos:prefLabel>
+            <skos:definition xml:lang="en">Concept definition</skos:definition>
+            <skos:member>
+            <skos:Concept rdf:about="https://vocab.met.no/mmd/concept/instance">
+                <skos:prefLabel xml:lang="en">Instance label</skos:prefLabel>
+                <skos:definition xml:lang="en">Instance definition</skos:definition>
+            </skos:Concept>
+            </skos:member>
+        </skos:Collection>
+        </rdf:RDF>
+    '''
+
+    def setUp(self):
+        self.voc = MMDVocabulary(name='test_voc', collection_label='Concept label')
+
+    def test_get_subnode_data(self):
+        """Test getting the data from a subnode"""
+        dom = xml.dom.minidom.parseString(self.base_file_contents)
+        collection = dom.childNodes[0].getElementsByTagName('skos:Collection')[0]
+        self.assertEqual(
+            self.voc.get_subnode_data(collection, 'skos:definition'),
+            'Concept definition')
+
+    def test_get_collection(self):
+        """Test getting the collection having a particular label"""
+        dom = xml.dom.minidom.parseString(self.base_file_contents)
+        self.assertEqual(
+            self.voc.get_collection(dom, 'Concept label'),
+            dom.childNodes[0].getElementsByTagName('skos:Collection')[0])
+
+
+    def test_fetch_online_data(self):
+        """Test that right collection is extracted"""
         # We use the exception as side effect to skip the part of the
         # method we are not testing.
         # TODO: split _fetch_online_data() into several methods instead
-
-        remote_page = '''<?xml version="1.0"?>
-            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-                xmlns:isothes="http://purl.org/iso25964/skos-thes#">
-            <skos:Collection rdf:about="https://vocab.met.no/mmd/concept">
-                <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
-                <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
-                <skos:prefLabel xml:lang="en">Concept label</skos:prefLabel>
-                <skos:definition xml:lang="en">Concept definition</skos:definition>
-                <skos:member>
-                <skos:Concept rdf:about="https://vocab.met.no/mmd/concept/instance">
-                    <skos:prefLabel xml:lang="en">Instance label</skos:prefLabel>
-                    <skos:definition xml:lang="en">Instance definition</skos:definition>
-                </skos:Concept>
-                </skos:member>
-            </skos:Collection>
-            </rdf:RDF>
-        '''
 
         expected_list = [
             OrderedDict([
@@ -50,24 +63,117 @@ class MMDVocabularyTest(unittest.TestCase):
                 ('definition', 'Instance definition')])
         ]
 
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.voc, '_download_data_file') as mock_download, \
+                mock.patch('pythesint.mmd_vocabulary.open') as mock_open:
+            # return a new buffer containing the desired contents
+            # every time open is called
+            mock_open.side_effect = lambda *a, **k: io.StringIO(self.base_file_contents)
+
+            version = 'master'
+            expected_list[0]['version'] = version
             # No version provided
-            mock_get.return_value.text = remote_page
-            self.assertListEqual(voc._fetch_online_data(), expected_list)
-            mock_get.assert_called_with(
-                'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+            self.assertCountEqual(self.voc._fetch_online_data(), expected_list)
+            mock_download.assert_called_with(version=version)
 
-            self.assertListEqual(voc._fetch_online_data(version=None), expected_list)
-            mock_get.assert_called_with(
-                'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+            self.assertCountEqual(self.voc._fetch_online_data(version=None), expected_list)
+            mock_download.assert_called_with(version=version)
 
-            self.assertListEqual(voc._fetch_online_data(version=''), expected_list)
-            mock_get.assert_called_with(
-                'https://raw.githubusercontent.com/metno/mmd/master/thesauri/mmd_operstatus.xml')
+            self.assertCountEqual(self.voc._fetch_online_data(version=''), expected_list)
+            mock_download.assert_called_with(version=version)
 
             # Version provided
             version = 'a5c8573'
             expected_list[0]['version'] = version
-            self.assertListEqual(voc._fetch_online_data(version=version), expected_list)
+            self.assertCountEqual(self.voc._fetch_online_data(version=version), expected_list)
+            mock_download.assert_called_with(version='a5c8573')
+
+    def test_get_local_file_github_blob_sha(self):
+        """Test that the correct hash is returned"""
+        buffer = io.BytesIO(b'file contents\n')
+        with mock.patch('pythesint.mmd_vocabulary.open') as mock_open, \
+                mock.patch('os.path.isfile', return_value=True):
+            mock_open.return_value.__enter__.return_value = buffer
+            self.assertEqual(
+                MMDVocabulary._get_local_file_github_blob_sha('test.txt'),
+                'd03e2425cf1c82616e12cb430c69aaa6cc08ff84')
+
+    def test_get_remote_file_github_blob_sha(self):
+        """Test that the correct sha is fetched from github's API"""
+        response = '''{
+            "sha": "20b5eab06834b02b609097e9285dba1e2d266fe0",
+            "url": "https://api.github.com/repos/metno/mmd/git/trees/20b5eab06834b02b609097e9285dba1e2d266fe0",
+            "tree": [
+                {
+                "path": "mmd-vocabulary.ttl",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "21bc582a136d0dac8461f66e169f25e067f05e3b",
+                "size": 89829,
+                "url": "https://api.github.com/repos/metno/mmd/git/blobs/21bc582a136d0dac8461f66e169f25e067f05e3b"
+                },
+                {
+                "path": "mmd-vocabulary.xml",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "4105803f5f54789116ba840afb5b4e7c22cb4286",
+                "size": 114697,
+                "url": "https://api.github.com/repos/metno/mmd/git/blobs/4105803f5f54789116ba840afb5b4e7c22cb4286"
+                }
+            ],
+            "truncated": false
+            }
+            '''
+        with mock.patch('requests.get') as mock_get:
+            mock_get.return_value.text = response
+            self.assertEqual(
+                self.voc._get_remote_file_github_blob_sha('master'),
+                '4105803f5f54789116ba840afb5b4e7c22cb4286')
             mock_get.assert_called_with(
-                'https://raw.githubusercontent.com/metno/mmd/a5c8573/thesauri/mmd_operstatus.xml')
+                'https://api.github.com/repos/metno/mmd/git/trees/master:thesauri')
+
+
+class DownloadTestCase(unittest.TestCase):
+    """Tests for the MMDVocabulary._download_data_file() method"""
+
+    def setUp(self):
+        self.voc = MMDVocabulary(name='test_voc', collection_label='foo')
+        self.mock_local_sha = mock.patch.object(self.voc, '_get_local_file_github_blob_sha').start()
+        self.mock_remote_sha = mock.patch.object(
+            self.voc, '_get_remote_file_github_blob_sha').start()
+        self.mock_open = mock.patch('pythesint.mmd_vocabulary.open').start()
+        self.mock_get = mock.patch('requests.get').start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_download_data_file_if_not_present(self):
+        """The file should be downloaded if it is not already there"""
+        with mock.patch('os.path.isfile', return_value=False):
+            self.voc._download_data_file()
+
+        self.mock_get.assert_called_with(self.voc.base_url, stream=True)
+
+    def test_download_data_file_if_sha_does_not_match(self):
+        """The file should be downloaded if the sha hashes do not match"""
+        with mock.patch('os.path.isfile', return_value=True):
+            self.mock_local_sha.return_value = 'a4b5'
+            self.mock_remote_sha.return_value = 'b4c2'
+            self.voc._download_data_file()
+
+        self.mock_get.assert_called_with(self.voc.base_url, stream=True)
+
+    def test_dont_download_data_file_if_sha_match(self):
+        """The file should not be downloaded if the sha hashes match"""
+        with mock.patch('os.path.isfile', return_value=True):
+            self.mock_local_sha.return_value = 'a4b5'
+            self.mock_remote_sha.return_value = 'a4b5'
+            self.voc._download_data_file()
+
+        self.mock_get.assert_not_called()
+
+    def test_download_data_file_version(self):
+        """Test that the specified version is downloaded"""
+        with mock.patch('os.path.isfile', return_value=False):
+            self.voc._download_data_file(version='v3.2')
+
+        self.mock_get.assert_called_with(
+            'https://raw.githubusercontent.com/metno/mmd/v3.2/thesauri/mmd-vocabulary.xml',
+            stream=True)


### PR DESCRIPTION
Resolves #54 

The tests fail because of problems solved in the following PRs: #57 #58.
I merged all pending PRs in a temporary branch to show that tests pass with all the fixes: 
https://github.com/nansencenter/py-thesaurus-interface/actions/runs/1425795952