### PR TITLE
Get GCMD categories from the source

### DIFF
--- a/pythesint/gcmd_vocabulary.py
+++ b/pythesint/gcmd_vocabulary.py
@@ -7,9 +7,16 @@ from pythesint.json_vocabulary import JSONVocabulary
 
 
 class GCMDVocabulary(JSONVocabulary):
+
+    def _check_categories(self, categories):
+        '''Print a warning if the categories are not the expected ones
+        '''
+        if set(self.categories) != set(categories):
+            print(f"Unexpected categories {categories}")
+
     def _fetch_online_data(self, version=None):
         ''' Return list of GCMD standard keywords
-            self.url and self.categories must be set
+            self.url must be set
         '''
         if version:
             params = {'version': version}
@@ -24,10 +31,14 @@ class GCMDVocabulary(JSONVocabulary):
             raise
         rlines = [line for line in r.text.splitlines()]
         gcmd_list = []
+
         _read_revision(rlines[0], gcmd_list)
-        _check_categories(rlines[1], self.categories)
+
+        categories = _get_categories(rlines)
+        self._check_categories(categories)
+
         for line in rlines[2:]:
-            _read_line(line, gcmd_list, self.categories)
+            _read_line(line, gcmd_list, categories)
 
         return gcmd_list
 
@@ -45,14 +56,9 @@ def _read_revision(line, gcmd_list):
         })
 
 
-def _check_categories(line, categories):
-    ''' Throws an exception if the line does not match categories
-    '''
-    kw_groups = line.split(',')
-    kw_groups.pop(-1)
-    # Make sure the group items are as expected
-    if kw_groups != categories:
-        raise TypeError('%s is not equal to %s' % (kw_groups, categories))
+def _get_categories(lines):
+    '''Get the categories from the lines read from the source'''
+    return lines[1].split(',')[:-1]
 
 
 def _read_line(line, gcmd_list, categories):

--- a/pythesint/tests/test_gcmd_vocabulary.py
+++ b/pythesint/tests/test_gcmd_vocabulary.py
@@ -31,17 +31,13 @@ class GCMDVocabularyTest(unittest.TestCase):
             {'Keyword Version': '8.1', 'Revision': '2016-01-08 13:40:40'})
 
     def test_check_categories(self):
-        line = ('Category,Class,Type,Subtype,Short_Name,Long_Name,UUID')
+        lines = [
+            'Revision',
+            'Category,Class,Type,Subtype,Short_Name,Long_Name,UUID'
+        ]
         categories = ['Category', 'Class', 'Type', 'Subtype', 'Short_Name',
                       'Long_Name']
-        pti.gcmd_vocabulary._check_categories(line, categories)
-
-    def test_check_categories_wrong(self):
-        line = ('Category,Class,Type,Subtype,Short_Name,Long_Name,UUID')
-        categories = ['Category', 'Type', 'Class', 'Subtype', 'Short_Name',
-                      'Long_Name']
-        with self.assertRaises(TypeError):
-            pti.gcmd_vocabulary._check_categories(line, categories)
+        self.assertListEqual(pti.gcmd_vocabulary._get_categories(lines), categories)
 
     def test_read_line_simple(self):
         gcmd_list = [{'Revision': '2016-01-08 13:40:40'}]


### PR DESCRIPTION
Resolves #53 

This is proposition on how to solve the problem raised in #53: when a category is added in the GCMD standard, addin git in pythesintrc.yaml breaks compatibility with previous versions of the GCMD vocabulary.

Categories are now read from the CSV file we get from gcmdservices.gsfc.nasa.gov.
It is still compared to the categories declared in the pythesintrc.yaml file, but a warning is just printed if they don't match.


The tests fail because of problems solved in the following PRs: #56 #58.
I merged all pending PRs in a temporary branch to show that tests pass with all the fixes: 
https://github.com/nansencenter/py-thesaurus-interface/actions/runs/1425795952