### PR TITLE
Pin pyyaml version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from os import path
 
 readme_file = 'README.md'
 NAME = 'pythesint'
-REQS = ['PyYAML', 'requests', 'xdg<=1.0.7;platform_system!="Windows"']
+REQS = ['PyYAML<6.0', 'requests', 'xdg<=1.0.7;platform_system!="Windows"']
 
 here = path.abspath(path.dirname(path.realpath(__file__)))
 


### PR DESCRIPTION
due to breaking change in pyyaml 6.0

The tests fail because of problems solved in the following PRs: #56 #57.
I merged all pending PRs in a temporary branch to show that tests pass with all the fixes: 
https://github.com/nansencenter/py-thesaurus-interface/actions/runs/1425795952