### PR TITLE
Enable the use of aliases for categories

### DIFF
--- a/pythesint/pythesintrc.yaml
+++ b/pythesint/pythesintrc.yaml
@@ -58,10 +58,14 @@
   kwargs:
     url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/platforms/?format=csv
     categories:
-      - Category
-      - Series_Entity
-      - Short_Name
-      - Long_Name
+      # these aliases ensure backwards compatibility for the time being
+      # the format is category_name: alias
+      # where category_name is the category name defined by the provider
+      Basis: Category
+      Category: Series_Entity
+      Sub_Category: ''
+      Short_Name: Short_Name
+      Long_Name: Long_Name
 
 - name: gcmd_location
   module: gcmd_vocabulary

--- a/pythesint/tests/test_vocabulary.py
+++ b/pythesint/tests/test_vocabulary.py
@@ -64,6 +64,36 @@ class VocabularyTest(unittest.TestCase):
         vocabulary_list = [{'Revision': '2016-01-08 13:40:40'}, entry]
         self.assertListEqual(vocabulary.sort_list(vocabulary_list), [OrderedDict(entry)])
 
+    def test_sort_list(self):
+        vocabulary = Vocabulary('test_vocabulary', categories=['Category', 'Type', 'Name'])
+        self.assertListEqual(
+            vocabulary.sort_list(self.test_list),
+            [
+                OrderedDict([('Category', 'Animal'), ('Type', 'Cat'), ('Name', '')]),
+                OrderedDict([('Category', 'Animal'), ('Type', 'Cat'), ('Name', 'The cat')]),
+                OrderedDict([('Category', 'Animal'), ('Type', ''), ('Name', '')]),
+                OrderedDict([('Category', 'Animal'), ('Type', 'Dog'), ('Name', '')]),
+                OrderedDict([('Category', 'Animal'), ('Type', 'Mouse'), ('Name', '')]),
+                OrderedDict([('Category', 'Construction'), ('Type', 'House'), ('Name', '')]),
+            ])
+
+    def test_sort_list_aliases(self):
+        vocabulary = Vocabulary('test_vocabulary', categories={
+            'Category': 'class',
+            'Type': 'kind',
+            'Name': ''
+        })
+        self.assertListEqual(
+            vocabulary.sort_list(self.test_list),
+            [
+                OrderedDict([('class', 'Animal'), ('kind', 'Cat'), ('Name', '')]),
+                OrderedDict([('class', 'Animal'), ('kind', 'Cat'), ('Name', 'The cat')]),
+                OrderedDict([('class', 'Animal'), ('kind', ''), ('Name', '')]),
+                OrderedDict([('class', 'Animal'), ('kind', 'Dog'), ('Name', '')]),
+                OrderedDict([('class', 'Animal'), ('kind', 'Mouse'), ('Name', '')]),
+                OrderedDict([('class', 'Construction'), ('kind', 'House'), ('Name', '')]),
+            ])
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']

--- a/pythesint/vocabulary.py
+++ b/pythesint/vocabulary.py
@@ -84,9 +84,18 @@ class Vocabulary(object):
         retlist = []
         for dd in list:
             line_kw = OrderedDict()
+            has_aliases = isinstance(self.categories, dict)
             try:
                 for key in self.categories:
-                    line_kw[key] = dd[key]
+                    if has_aliases:
+                        # self.categories is a dict defining aliases
+                        alias = self.categories.get(key)
+                        # if an empty alias is defined, use the original category name
+                        field_name = alias if alias else key
+                    else:
+                        # no alias is defined, just use the category name
+                        field_name = key
+                    line_kw[field_name] = dd[key]
             except KeyError:
                 continue
             retlist.append(line_kw)


### PR DESCRIPTION
Resolves #61 

The `categories` field in `pythesintrc.yaml` now accepts a dictionary with the following structure:
`category_name: alias`
where category_name is the category name defined by the provider.

The dictionaries returned by pythesint will have keys named with the aliases.
Here, we use this to keep the old field names for the GCMD platforms to ensure backwards compatibility.