### PR TITLE
Edited GCMD Links

### DIFF
--- a/pythesint/basedata/gcmd_horizontalresolutionrange
+++ b/pythesint/basedata/gcmd_horizontalresolutionrange
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2013-03-19 10:35:29","Timestamp: 2016-02-26 04:47:38","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/horizontalresolutionrange/?format=xml"
+"Keyword Version: 8.1","Revision: 2013-03-19 10:35:29","Timestamp: 2016-02-26 04:47:38","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/horizontalresolutionrange/?format=xml"
 Horizontal_Resolution_Range,UUID
 "1 km - < 10 km or approximately .01 degree - < .09 degree","6dd8224f-944e-4798-ac48-44c23a567eeb"
 "1 meter - < 30 meters","abf43d91-a65d-4b3b-a6dd-593e211b2c7b"

--- a/pythesint/basedata/gcmd_instrument
+++ b/pythesint/basedata/gcmd_instrument
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2016-01-08 13:40:40","Timestamp: 2016-02-26 04:46:02","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/instruments/?format=xml"
+"Keyword Version: 8.1","Revision: 2016-01-08 13:40:40","Timestamp: 2016-02-26 04:46:02","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments/?format=xml"
 Category,Class,Type,Subtype,Short_Name,Long_Name,UUID
 "Earth Remote Sensing Instruments","","","","","","6015ef7b-f3bd-49e1-9193-cc23db566b69"
 "Earth Remote Sensing Instruments","Active Remote Sensing","","","","","c8fe757b-b530-4d67-a553-e4903f4430a5"

--- a/pythesint/basedata/gcmd_location
+++ b/pythesint/basedata/gcmd_location
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2015-04-07 14:37:24","Timestamp: 2016-02-26 04:47:18","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/locations/?format=xml"
+"Keyword Version: 8.1","Revision: 2015-04-07 14:37:24","Timestamp: 2016-02-26 04:47:18","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations/?format=xml"
 Location_Category,Location_Type,Location_Subregion1,Location_Subregion2,Location_Subregion3,UUID
 "CONTINENT","","","","","0a672f19-dad5-4114-819a-2eb55bdbb56a"
 "CONTINENT","AFRICA","","","","2ca1b865-5555-4375-aa81-72811335b695"

--- a/pythesint/basedata/gcmd_platform
+++ b/pythesint/basedata/gcmd_platform
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2016-01-11 15:05:11","Timestamp: 2016-02-26 04:47:04","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/platforms/?format=xml"
+"Keyword Version: 8.1","Revision: 2016-01-11 15:05:11","Timestamp: 2016-02-26 04:47:04","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms/?format=xml"
 Category,Series_Entity,Short_Name,Long_Name,UUID
 "Aircraft","","","","227d9c3d-f631-402d-84ed-b8c5a562fc27"
 "Aircraft","","A340-600","Airbus A340-600","bab77f95-aa34-42aa-9a12-922d1c9fae63"

--- a/pythesint/basedata/gcmd_project
+++ b/pythesint/basedata/gcmd_project
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2016-01-10 17:41:43","Timestamp: 2016-02-26 04:48:50","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/projects/?format=xml"
+"Keyword Version: 8.1","Revision: 2016-01-10 17:41:43","Timestamp: 2016-02-26 04:48:50","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/projects/?format=xml"
 Bucket,Short_Name,Long_Name,UUID
 "A - C","","","0c89f3f4-7ab1-43ce-89ee-795d35f0e30a"
 "A - C","AA","ARCATLAS","a30ac9a7-82b0-42b6-93db-2764bd7535ca"

--- a/pythesint/basedata/gcmd_provider
+++ b/pythesint/basedata/gcmd_provider
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2015-12-29 15:16:49","Timestamp: 2016-02-26 04:46:44","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/providers/?format=xml"
+"Keyword Version: 8.1","Revision: 2015-12-29 15:16:49","Timestamp: 2016-02-26 04:46:44","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/providers/?format=xml"
 Bucket_Level0,Bucket_Level1,Bucket_Level2,Bucket_Level3,Short_Name,Long_Name,Data_Center_URL,UUID
 "ACADEMIC","","","","","","","7700280b-68ee-4644-bf5e-84e7a6adf897"
 "ACADEMIC","","","","AALTO","Aalto University","","d50d54e6-6ea5-4579-bbc7-98afffd8b443"

--- a/pythesint/basedata/gcmd_rucontenttype
+++ b/pythesint/basedata/gcmd_rucontenttype
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2016-01-07 13:31:43","Timestamp: 2016-02-26 04:49:04","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/rucontenttype/?format=xml"
+"Keyword Version: 8.1","Revision: 2016-01-07 13:31:43","Timestamp: 2016-02-26 04:49:04","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/rucontenttype/?format=xml"
 Type,Subtype,UUID
 "GET DATA","","750f6c61-0f15-4185-94d8-c029dec04bc5"
 "GET DATA","DATACAST URL","2fc3797c-71b5-4d01-8ae1-d5634ec625ce"

--- a/pythesint/basedata/gcmd_science_keyword
+++ b/pythesint/basedata/gcmd_science_keyword
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2016-01-06 15:02:22","Timestamp: 2016-02-26 04:46:17","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/?format=xml"
+"Keyword Version: 8.1","Revision: 2016-01-06 15:02:22","Timestamp: 2016-02-26 04:46:17","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/?format=xml"
 Category,Topic,Term,Variable_Level_1,Variable_Level_2,Variable_Level_3,Detailed_Variable,UUID
 "EARTH SCIENCE","","","","","","","e9f67a66-e9fc-435c-b720-ae32a2c3d8f5"
 "EARTH SCIENCE SERVICES","","","","","","","894f9116-ae3c-40b6-981d-5113de961710"

--- a/pythesint/basedata/gcmd_temporalresolutionrange
+++ b/pythesint/basedata/gcmd_temporalresolutionrange
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2012-10-19 14:09:54","Timestamp: 2016-02-26 04:48:34","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/temporalresolutionrange/?format=xml"
+"Keyword Version: 8.1","Revision: 2012-10-19 14:09:54","Timestamp: 2016-02-26 04:48:34","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/temporalresolutionrange/?format=xml"
 Temporal_Resolution_Range,UUID
 "1 minute - < 1 hour","bca20202-2b06-4657-a425-5b0e416bce0c"
 "1 second - < 1 minute","48ff676f-836c-4cff-bc88-4c4cc06b2e1b"

--- a/pythesint/basedata/gcmd_verticalresolutionrange
+++ b/pythesint/basedata/gcmd_verticalresolutionrange
@@ -1,4 +1,4 @@
-"Keyword Version: 8.1","Revision: 2012-10-19 14:09:54","Timestamp: 2016-02-26 04:48:14","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/verticalresolutionrange/?format=xml"
+"Keyword Version: 8.1","Revision: 2012-10-19 14:09:54","Timestamp: 2016-02-26 04:48:14","Terms Of Use: See http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/verticalresolutionrange/?format=xml"
 Vertical_Resolution_Range,UUID
 "1 meter - < 10 meters","201337ea-fa14-4e58-a538-e92c5ff734a4"
 "10 meters - < 30 meters","20505a5b-4df8-4430-83a3-ad7b212c9bfc"

--- a/pythesint/pythesintrc.yaml
+++ b/pythesint/pythesintrc.yaml
@@ -20,7 +20,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/instruments/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments/?format=csv
     categories:
       - Category
       - Class
@@ -33,7 +33,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/?format=csv
     categories:
       - Category
       - Topic
@@ -47,7 +47,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/providers/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/providers/?format=csv
     categories:
       - Bucket_Level0
       - Bucket_Level1
@@ -61,7 +61,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/platforms/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms/?format=csv
     categories:
       - Category
       - Series_Entity
@@ -72,7 +72,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/locations/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations/?format=csv
     categories:
       - Location_Category
       - Location_Type
@@ -84,7 +84,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/horizontalresolutionrange/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/horizontalresolutionrange/?format=csv
     categories:
       - Horizontal_Resolution_Range
 
@@ -92,7 +92,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/verticalresolutionrange/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/verticalresolutionrange/?format=csv
     categories:
       - Vertical_Resolution_Range
 
@@ -100,7 +100,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/temporalresolutionrange/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/temporalresolutionrange/?format=csv
     categories:
       - Temporal_Resolution_Range
 
@@ -108,7 +108,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/projects/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/projects/?format=csv
     categories:
       - Bucket
       - Short_Name
@@ -118,7 +118,7 @@
   module: gcmd_vocabulary
   class: GCMDVocabulary
   kwargs:
-    url: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/rucontenttype/?format=csv
+    url: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/rucontenttype/?format=csv
     categories:
       - Type
       - Subtype

--- a/pythesint/tests/test_gcmd_vocabulary.py
+++ b/pythesint/tests/test_gcmd_vocabulary.py
@@ -22,7 +22,7 @@ class GCMDVocabularyTest(unittest.TestCase):
                 'Timestamp: 2016-02-26 04:46:02","Terms Of Use: See '
                 'http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML'
                 ' representations can be found here: '
-                'http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme'
+                'http://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme'
                 '/instruments/?format=xml"')
         pti.gcmd_vocabulary._read_revision(line, gcmd_list)
         self.assertEqual(len(gcmd_list), 1)


### PR DESCRIPTION
Removed deprecated GCMD links - added new ones. This should hopefully allow pythesint to run successfully with the updated links. 